### PR TITLE
Add a config file to change the installed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,12 @@ libharfbuzz0b
 libharfbuzz-icu0
 ```
 
+Optionally, create a `LibreOfficeAppImage` file to change the installed version to something other than the latest `fresh`.
+The file should contain only two lines; one for the version and one for the url to an AppImage.
+For example the latest `still` can be installed with:
+```
+still.basic-x86_64
+https://libreoffice.soluzioniopen.com/stable/still/LibreOffice-still.basic-x86_64.AppImage
+```
+
 Redeploy your project after committing the above file, et voilà...!

--- a/bin/compile
+++ b/bin/compile
@@ -11,8 +11,13 @@ mkdir -p $INSTALL_DIR
 CACHE_DIR=$2 # the contents of CACHE_DIR are persisted between builds
 
 # libreoffice
-VERSION="fresh.basic-x86_64"
-DOWNLOAD="https://libreoffice.soluzioniopen.com/stable/fresh/LibreOffice-${VERSION}.AppImage"
+if [ -f $BUILD_DIR/LibreOfficeAppImage ] ; then
+    VERSION=$(grep -v http $BUILD_DIR/LibreOfficeAppImage | head -n 1)
+    DOWNLOAD=$(grep http $BUILD_DIR/LibreOfficeAppImage | head -n 1)
+else
+    VERSION="fresh.basic-x86_64"
+    DOWNLOAD="https://libreoffice.soluzioniopen.com/stable/fresh/LibreOffice-fresh.basic-x86_64.AppImage"
+fi
 FILE_NAME=LibreOffice-${VERSION}.AppImage
 
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
The config file could be simplified to contain only the url for the AppImage, since the version string can be almost anything.
I tested this with and without `LibreOfficeAppImage` and it seems to work as intended.
The slug size seemed to stay below 300MB the whole time, even after switching versions.