### PR TITLE
Parse the used version from the url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fully working LibreOffice 6.1.3 buildpack for the heroku-18 stack 🎉
+# Fully working LibreOffice buildpack for the heroku-18 stack 🎉
 
 Shamefully simple, and utilising an official AppImage copy of LibreOffice with its dependencies directly from the vendor... a frustration-free, working buildpack for LibreOffice 6.1.3 (others possibly supported via a variable change) on the heroku-18 stack (others possibly supported but you may be asking for trouble if you try), after a lot of trial & error.
 
@@ -32,10 +32,9 @@ libharfbuzz-icu0
 ```
 
 Optionally, create a `LibreOfficeAppImage` file to change the installed version to something other than the latest `fresh`.
-The file should contain only two lines; one for the version and one for the url to an AppImage.
+The file should contain only an url for an AppImage.
 For example the latest `still` can be installed with:
 ```
-still.basic-x86_64
 https://libreoffice.soluzioniopen.com/stable/still/LibreOffice-still.basic-x86_64.AppImage
 ```
 

--- a/bin/compile
+++ b/bin/compile
@@ -12,12 +12,12 @@ CACHE_DIR=$2 # the contents of CACHE_DIR are persisted between builds
 
 # libreoffice
 if [ -f $BUILD_DIR/LibreOfficeAppImage ] ; then
-    VERSION=$(grep -v http $BUILD_DIR/LibreOfficeAppImage | head -n 1)
     DOWNLOAD=$(grep http $BUILD_DIR/LibreOfficeAppImage | head -n 1)
 else
-    VERSION="fresh.basic-x86_64"
     DOWNLOAD="https://libreoffice.soluzioniopen.com/stable/fresh/LibreOffice-fresh.basic-x86_64.AppImage"
 fi
+VERSION=$(echo $DOWNLOAD | grep -Poi "(?<=LibreOffice-)[^/]+(?=\.AppImage)")
+VERSION=${VERSION:-default} # avoid empty version if the grep fails to match
 FILE_NAME=LibreOffice-${VERSION}.AppImage
 
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
The cache contents will always get reused if the filename isn't following the same structure as the official ones.
Is this acceptable behavior?