### PR TITLE
Update README.md for other required shared libraries libX11-xcb 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ libxinerama1
 libdbus-glib-1-2
 libharfbuzz0b
 libharfbuzz-icu0
+libx11-xcb1
+libxcb1
 ```
 
 Optionally, create a `LibreOfficeAppImage` file in your application repository to change the installed version to something other than the latest `fresh`.


### PR DESCRIPTION
I got the following error using this buildpack: 
"javaldx: Could not find a Java Runtime Environment!\nWarning: failed to read path from javaldx\n/app/vendor/libreoffice/opt/libreoffice7.0/program/soffice.bin: error while loading shared libraries: libX11-xcb.so.1: cannot open shared object file: No such file or directory"

Updating README.md to let others know this is how to fix the issue